### PR TITLE
refactor: change namespace 'null' to 'nulltransport'

### DIFF
--- a/NullConnectionFactory.php
+++ b/NullConnectionFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Context;

--- a/NullConsumer.php
+++ b/NullConsumer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\Destination;

--- a/NullContext.php
+++ b/NullContext.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\Context;

--- a/NullMessage.php
+++ b/NullMessage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Message;
 

--- a/NullProducer.php
+++ b/NullProducer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Destination;
 use Interop\Queue\Message;

--- a/NullQueue.php
+++ b/NullQueue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Queue;
 

--- a/NullSubscriptionConsumer.php
+++ b/NullSubscriptionConsumer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Consumer;
 use Interop\Queue\SubscriptionConsumer;

--- a/NullTopic.php
+++ b/NullTopic.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enqueue\Null;
+namespace Enqueue\NullTransport;
 
 use Interop\Queue\Topic;
 

--- a/Tests/NullConnectionFactoryTest.php
+++ b/Tests/NullConnectionFactoryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullConnectionFactory;
-use Enqueue\Null\NullContext;
+use Enqueue\NullTransport\NullConnectionFactory;
+use Enqueue\NullTransport\NullContext;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\ConnectionFactory;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullConsumerTest.php
+++ b/Tests/NullConsumerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullConsumer;
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullQueue;
+use Enqueue\NullTransport\NullConsumer;
+use Enqueue\NullTransport\NullMessage;
+use Enqueue\NullTransport\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Consumer;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullContextTest.php
+++ b/Tests/NullContextTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullConsumer;
-use Enqueue\Null\NullContext;
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullProducer;
-use Enqueue\Null\NullQueue;
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransport\NullConsumer;
+use Enqueue\NullTransport\NullContext;
+use Enqueue\NullTransport\NullMessage;
+use Enqueue\NullTransport\NullProducer;
+use Enqueue\NullTransport\NullQueue;
+use Enqueue\NullTransport\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Context;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullMessageTest.php
+++ b/Tests/NullMessageTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullMessage;
+use Enqueue\NullTransport\NullMessage;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Message;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullProducerTest.php
+++ b/Tests/NullProducerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullMessage;
-use Enqueue\Null\NullProducer;
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransport\NullMessage;
+use Enqueue\NullTransport\NullProducer;
+use Enqueue\NullTransport\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Producer;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullQueueTest.php
+++ b/Tests/NullQueueTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullQueue;
+use Enqueue\NullTransport\NullQueue;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Queue;
 use PHPUnit\Framework\TestCase;

--- a/Tests/NullTopicTest.php
+++ b/Tests/NullTopicTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests;
+namespace Enqueue\NullTransport\Tests;
 
-use Enqueue\Null\NullTopic;
+use Enqueue\NullTransport\NullTopic;
 use Enqueue\Test\ClassExtensionTrait;
 use Interop\Queue\Topic;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Spec/NullMessageTest.php
+++ b/Tests/Spec/NullMessageTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enqueue\Null\Tests\Spec;
+namespace Enqueue\NullTransport\Tests\Spec;
 
-use Enqueue\Null\NullMessage;
+use Enqueue\NullTransport\NullMessage;
 use Interop\Queue\Spec\MessageSpec;
 
 class NullMessageTest extends MessageSpec

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md"
     },
     "autoload": {
-        "psr-4": { "Enqueue\\Null\\": "" },
+        "psr-4": { "Enqueue\\NullTransport\\": "" },
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
'null' is a reserved keyword as of PHP version 7.0 and should not be used to name a class, interface or trait or as part of a namespace (T_NAMESPACE)

Namespaces are replaced everywhere, including autoload. Unit tests are running as before.